### PR TITLE
Fix link to Lanyon in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -17,6 +17,6 @@
   </nav>
   <footer class="sidebar-item" role="contentinfo">
     Tom &hearts;
-    <a href="http://http://lanyon.getpoole.com/">Lanyon</a>
+    <a href="http://lanyon.getpoole.com/">Lanyon</a>
   </footer>
 </div>


### PR DESCRIPTION
A wee fix for a broken link I spotted while reading [your delightful post](http://www.tomharding.me/2017/04/15/functions-as-functors/) about functions as functors.

![fixo](https://cloud.githubusercontent.com/assets/1855109/25063156/da606d8c-21d4-11e7-82e8-0bc6c878f535.png)
