### PR TITLE
Correct List.prototype.equals

### DIFF
--- a/_posts/2017-03-09-fantas-eel-and-specification-3.md
+++ b/_posts/2017-03-09-fantas-eel-and-specification-3.md
@@ -47,10 +47,10 @@ List.prototype.equals = function (that) {
   return this.cata({
     // Note the two different Setoid uses:
     Cons: (head, tail) =>
-      head.equals(that.head) // a
+      head === that.head // a
         && tail.equals(that.tail), // [a]
 
-    Nil: () => that instanceof List.Nil
+    Nil: () => that.is(List.Nil)
   })
 }
 ```

--- a/_posts/2017-03-09-fantas-eel-and-specification-3.md
+++ b/_posts/2017-03-09-fantas-eel-and-specification-3.md
@@ -47,7 +47,7 @@ List.prototype.equals = function (that) {
   return this.cata({
     // Note the two different Setoid uses:
     Cons: (head, tail) =>
-      head === that.head // a
+      head.equals(that.head) // a
         && tail.equals(that.tail), // [a]
 
     Nil: () => that.is(List.Nil)


### PR DESCRIPTION
Hi Tom,

first of all thanks for writing the [blog series](http://www.tomharding.me/2017/03/03/fantas-eel-and-specification/) which is super awesome. As an avid user of both ramda and folktale I enjoy learning about fantasyland very much. 
I'm currently at [chapter 3](http://www.tomharding.me/2017/03/09/fantas-eel-and-specification-3/) and I tripped over your `List.prototype.equals` definition:
```
// Check the lists' heads, then their tails
// equals :: Setoid a => [a] ~> [a] -> Bool
List.prototype.equals = function (that) {
  return this.cata({
    // Note the two different Setoid uses:
    Cons: (head, tail) =>
      head.equals(that.head) // a
        && tail.equals(that.tail), // [a]

    Nil: () => that instanceof List.Nil
  })
}
```
While reading along I tend to play around with the code to get a better feeling for it and I noticed that the equals method did not work for me. `TypeError: head.equals is not a function` it would keep telling me. And rightly so, because head is an instance of Number which does not have an equals method. So I checked out your repository, rolled back to commit [f7a485b3bf7f2c87a3142fdf252df7dee28640cd](https://github.com/i-am-tom/fantas-eel-and-specification/commit/f7a485b3bf7f2c87a3142fdf252df7dee28640cd) so I could run your tests.
Imagine my confusion when your tests just ran fine. After a while I've discovered that you smuggled in equals via
```
Number.prototype.equals = function (that) {
  return Number(this) === Number(that)
}
```
And you could maybe fix another issue with the equals method above. After having fixed the equals issue, I tripped over `TypeError: Right-hand side of 'instanceof' is not callable` which thrown because [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) can only be used with constructors which `Nil` is not.

My (now working) definition ended up looking like this:
```
// Check the lists' heads, then their tails
// equals :: Setoid a => [a] ~> [a] -> Bool
List.prototype.equals = function (that) {
    return this.cata({
        // Note the two different Setoid uses:
        Cons: (head, tail) => head === that.head // a
            && tail.equals(that.tail), // [a]

        Nil: () => that.is(List.Nil)
    })
};
```

Would you please consider merging my pull request or correct this in another way? Thanks!

And thanks again for the great series! I will most certainly continue reading it.

Christian

