### PR TITLE
Add link to the Fantasy Land series to sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -15,6 +15,16 @@
       <i class="fa fa-stack-overflow fa-lg fa-fw"></i> Stack Overflow
     </a>
   </nav>
+
+  <h2 class="sidebar-nav-title">
+    Collections
+  </h2>
+  <nav class="sidebar-nav" role="navigation">
+    <a class="sidebar-nav-item" href="/fantasy-land">
+      Fantas, Eel, and Specification
+    </a>
+  </nav>
+
   <footer class="sidebar-item" role="contentinfo">
     Tom &hearts;
     <a href="http://lanyon.getpoole.com/">Lanyon</a>

--- a/css/lanyon.css
+++ b/css/lanyon.css
@@ -301,13 +301,20 @@ tbody tr:nth-child(odd) th { background-color: #F9F9F9 }
 
 .sidebar-item { padding: 1rem }
 .sidebar-item p:last-child { margin-bottom: 0 }
-
 .sidebar-item strong {
   color: rgba(255, 255, 255, .8);
   font-weight: bold;
 }
 
 .sidebar-nav { border-bottom: 1px solid rgba(255, 255, 255, .1) }
+
+.sidebar-nav-title {
+  color: rgba(255, 255, 255, .8);
+  font-size: 1.25em;
+  font-weight: bold;
+  margin-top: 2rem;
+  padding: .5rem 1rem;
+}
 
 .sidebar-nav-item {
   display: block;
@@ -325,6 +332,11 @@ a.sidebar-nav-item:focus {
 
 @media (min-width: 48em) {
   .sidebar-item { padding: 1.5rem }
+
+  .sidebar-nav-title {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 
   .sidebar-nav-item {
     padding-left: 1.5rem;
@@ -390,7 +402,7 @@ a.sidebar-nav-item:focus {
           transform: translateX(14rem);
 }
 
-footer.sidebar-item { text-align: center }
+footer.sidebar-item { text-align: left; }
 
 /* -- Posts -- */
 

--- a/fantasy-land.html
+++ b/fantasy-land.html
@@ -9,7 +9,7 @@ title: Fantas, Eel, and Specification
      href="https://github.com/fantasyland/fantasy-land">Fantasy Land</a>
   JavaScript specification, and to introduce some concepts of functional
   programming.</p>
-  <ul class="posts">
+  <ol class="posts">
     <li><a href="/2017/03/03/fantas-eel-and-specification/">Daggy</a></li>
     <li><a href="/2017/03/08/fantas-eel-and-specification-2/">Type Signatures</a></li>
     <li><a href="/2017/03/09/fantas-eel-and-specification-3/">Setoid</a></li>
@@ -30,5 +30,5 @@ title: Fantas, Eel, and Specification
     <li><a href="/2017/06/19/fantas-eel-and-specification-17/">Comonad</a></li>
     <li><a href="/2017/06/26/fantas-eel-and-specification-18/">Bifunctor and Profunctor</a></li>
     <li><a href="/2017/07/10/fantas-eel-and-specification-19/">Semigroupoid and Category</a></li>
-  </ul>
+  </ol>
 </div>


### PR DESCRIPTION
* Add link to the Fantasy Land series to the sidebar
* List the Fantasy Land posts as a numbered list to make it easier to navigate (because reading it in order makes sense …)

Here's how it looks: 
![th](https://user-images.githubusercontent.com/10811/34962453-fe3a3236-fa43-11e7-8ca5-c24934567feb.png)
